### PR TITLE
Enable local API server and enforce upload size

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 - Paste this code into your file and replace with your own values.
 ```
 BOT_API_KEY = "9999999999:AAHePL8-xSzjOlnF5dRGiwhNyxxZsS3u7f4" # Replace with your own token
+# Optional: point to your local API server to enable 2GB uploads
+BOT_API_URL = "http://localhost:8081"
 ```
 - Save it!
   

--- a/bot.py
+++ b/bot.py
@@ -9,6 +9,11 @@ load_dotenv()
 
 TOKEN = os.getenv("BOT_API_KEY")
 
+# Configure custom API server if provided
+custom_api_url = os.getenv("BOT_API_URL")
+if custom_api_url:
+    telebot.apihelper.API_URL = f"{custom_api_url.rstrip('/')}/bot{{0}}/{{1}}"
+
 bot = telebot.TeleBot(TOKEN, parse_mode="HTML")
                       
 @bot.message_handler(commands=['start'])

--- a/modules/checker.py
+++ b/modules/checker.py
@@ -74,9 +74,9 @@ def qualityChecker(bot, message, videoURL):
     # Add Inline Buttons to get user input
 
     def gen_markup():
-        markup = InlineKeyboardMarkup() 
-        for value in showList.values(): 
-            callbackData = f"{ value["q"] }#{ videoURL }"
+        markup = InlineKeyboardMarkup()
+        for value in showList.values():
+            callbackData = f"{value['q']}#{videoURL}"
             button = InlineKeyboardButton(text=f"{value['q']} ({value['size']})", callback_data=callbackData)
             markup.add(button)
         return markup

--- a/modules/ytdownloader.py
+++ b/modules/ytdownloader.py
@@ -27,6 +27,16 @@ def download(bot, message, userInput, videoURL):
             api.save(third_dict=video_metadata, dir="vids", naming_format=vidFileName, progress_bar=True)
         except Exception as e:
             bot.reply_to(message, f"Error downloading video: {e}")
+            continue
+
+        file_path = os.path.join(mediaPath, vidFileName)
+        file_size = os.path.getsize(file_path)
+        max_size = 2 * 1024 * 1024 * 1024
+        if file_size > max_size:
+            bot.edit_message_text(chat_id=downloadMsg.chat.id, message_id=downloadMsg.message_id, text="<b>File too large to upload (over 2GB).</b>")
+            bot.reply_to(message, "Please choose a lower quality option.")
+            os.remove(file_path)
+            continue
 
         bot.edit_message_text(chat_id=downloadMsg.chat.id, message_id=downloadMsg.message_id, text="<b>Uploading...📤</b>")
 


### PR DESCRIPTION
## Summary
- support using a local Telegram Bot API server via `BOT_API_URL`
- document `BOT_API_URL` in README
- fix callback button creation in `checker.py`
- check for 2GB upload limit before sending video

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684df04c504c832c813af96eb50dccbc