### PR TITLE
Enable local API server and enforce upload size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+# Use an official Python runtime as a parent image
+FROM --platform=$BUILDPLATFORM python:3.11-slim
+# Build for the detected build platform but image will be portable to TARGETPLATFORM
+
+# Metadata showing the build and target architecture
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+# Set PYTHONUNBUFFERED to get logs straight away
+ENV PYTHONUNBUFFERED=1
+
+# Set the working directory
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application
+COPY . .
+
+# Default command to run the bot
+CMD ["python", "bot.py"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 - Paste this code into your file and replace with your own values.
 ```
 BOT_API_KEY = "9999999999:AAHePL8-xSzjOlnF5dRGiwhNyxxZsS3u7f4" # Replace with your own token
+# Optional: point to your local API server to enable 2GB uploads
+BOT_API_URL = "http://localhost:8081"
 ```
 - Save it!
   
@@ -51,6 +53,60 @@ Read the instructions on [eternnoir/pyTelegramBotAPI](https://github.com/eternno
 - run: ```python bot.py```
 
 **both script & api server should run at the same time order to work.**
+
+### 5. Deploy with Docker
+1. Create a `.env` file containing your `BOT_API_KEY` and optional `BOT_API_URL`.
+2. Build and start the container using docker-compose:
+   ```bash
+   docker-compose up -d --build
+   ```
+The compose file builds the image for `linux/amd64` so it runs on an x86 VPS
+   even if you build from an Apple Silicon machine. Traefik is configured to
+   expose the bot at **bot.sherlockramos.tech**.
+
+## API
+
+The bot exposes a small command based API over Telegram. Interact using the
+standard Telegram Bot API by sending messages to your bot. Below are the
+available endpoints and their behaviour.
+
+### Endpoints
+
+| Command/Action | Description |
+|---------------|-------------|
+| `/start` | Greet the user and provide a short introduction. |
+| `/help` | Display instructions on how to download a video. |
+| `YouTube link` | Send any message containing a valid YouTube URL. The bot will reply with a list of quality options as inline buttons. |
+| `Quality button` | When a button is pressed the bot downloads the video and uploads it back. |
+
+### Request and Response Format
+
+All interactions occur via Telegram messages. Requests are regular text messages
+or callback data from inline buttons. Responses are text messages or video
+files. Example flows:
+
+```text
+User: /start
+Bot: Hello, I'm a Simple Youtube Downloader!👋
+
+User: /help
+Bot: <b>Just send your youtube link and select the video quality.</b> …
+
+User: https://youtu.be/dQw4w9WgXcQ
+Bot: Choose a stream:
+  [360p] [720p]
+
+User presses 720p button
+Bot: sends the video file (if under 2GB)
+```
+
+### Limitations
+
+- Files larger than **2 GB** will not be uploaded; choose a lower quality if the
+  selected stream exceeds this size.
+- Only YouTube links are recognized.
+- Without a local Bot API server (`BOT_API_URL`) uploads are limited to 50 MB by
+  Telegram's default servers.
 #
 
 ## Disclaimer

--- a/bot.py
+++ b/bot.py
@@ -9,6 +9,11 @@ load_dotenv()
 
 TOKEN = os.getenv("BOT_API_KEY")
 
+# Configure custom API server if provided
+custom_api_url = os.getenv("BOT_API_URL")
+if custom_api_url:
+    telebot.apihelper.API_URL = f"{custom_api_url.rstrip('/')}/bot{{0}}/{{1}}"
+
 bot = telebot.TeleBot(TOKEN, parse_mode="HTML")
                       
 @bot.message_handler(commands=['start'])

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+# Example docker-compose setup for deploying the bot
+# Customize variables in an .env file
+version: '3.9'
+
+services:
+  bot:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      # Build for x86_64 even on arm hosts
+      platform: linux/amd64
+    environment:
+      - BOT_API_KEY=${BOT_API_KEY}
+      - BOT_API_URL=${BOT_API_URL}
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.telegram-bot.rule=Host(`bot.sherlockramos.tech`)"
+      - "traefik.http.routers.telegram-bot.entrypoints=websecure"
+      - "traefik.http.routers.telegram-bot.tls=true"

--- a/modules/checker.py
+++ b/modules/checker.py
@@ -74,9 +74,9 @@ def qualityChecker(bot, message, videoURL):
     # Add Inline Buttons to get user input
 
     def gen_markup():
-        markup = InlineKeyboardMarkup() 
-        for value in showList.values(): 
-            callbackData = f"{ value["q"] }#{ videoURL }"
+        markup = InlineKeyboardMarkup()
+        for value in showList.values():
+            callbackData = f"{value['q']}#{videoURL}"
             button = InlineKeyboardButton(text=f"{value['q']} ({value['size']})", callback_data=callbackData)
             markup.add(button)
         return markup

--- a/modules/ytdownloader.py
+++ b/modules/ytdownloader.py
@@ -27,6 +27,16 @@ def download(bot, message, userInput, videoURL):
             api.save(third_dict=video_metadata, dir="vids", naming_format=vidFileName, progress_bar=True)
         except Exception as e:
             bot.reply_to(message, f"Error downloading video: {e}")
+            continue
+
+        file_path = os.path.join(mediaPath, vidFileName)
+        file_size = os.path.getsize(file_path)
+        max_size = 2 * 1024 * 1024 * 1024
+        if file_size > max_size:
+            bot.edit_message_text(chat_id=downloadMsg.chat.id, message_id=downloadMsg.message_id, text="<b>File too large to upload (over 2GB).</b>")
+            bot.reply_to(message, "Please choose a lower quality option.")
+            os.remove(file_path)
+            continue
 
         bot.edit_message_text(chat_id=downloadMsg.chat.id, message_id=downloadMsg.message_id, text="<b>Uploading...📤</b>")
 


### PR DESCRIPTION
## Summary
- support using a local Telegram Bot API server via `BOT_API_URL`
- document `BOT_API_URL` in README
- fix callback button creation in `checker.py`
- check for 2GB upload limit before sending video
- add Dockerfile and docker-compose for deployment
- add API documentation for the bot

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684df04c504c832c813af96eb50dccbc